### PR TITLE
feat(style-dictionary): optional outputPath

### DIFF
--- a/packages/style-dictionary/src/executors/build/executor.ts
+++ b/packages/style-dictionary/src/executors/build/executor.ts
@@ -31,7 +31,7 @@ export async function buildExecutor(
     );
   });
 
-  if (deleteOutputPath) {
+  if (options.outputPath && deleteOutputPath) {
     deleteOutputDir(context.root, outputPath);
   }
 

--- a/packages/style-dictionary/src/executors/build/lib/normalize-options.ts
+++ b/packages/style-dictionary/src/executors/build/lib/normalize-options.ts
@@ -18,7 +18,7 @@ export function normalizeOptions(
     root,
     projectRoot,
     sourceRoot,
-    outputPath: resolve(root, options.outputPath),
+    outputPath: resolve(root, options.outputPath ?? ''),
     styleDictionaryConfig: resolve(root, options.styleDictionaryConfig),
     tsConfig: resolve(root, options.tsConfig),
   };

--- a/packages/style-dictionary/src/executors/build/schema.json
+++ b/packages/style-dictionary/src/executors/build/schema.json
@@ -64,5 +64,5 @@
       "description": "Build only the passed platform defined in the configuration."
     }
   },
-  "required": ["styleDictionaryConfig", "tsConfig", "outputPath"]
+  "required": ["styleDictionaryConfig", "tsConfig"]
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(playwright): button content overflow` -->

## Current Behavior

All platform are forced to generate files under a single shared outputPath in the `project.json`.

## Expected Behavior

The `outputPath` in the `project.json` config should option to allow each Style Dictionary configuration platform define it's own build path relative to the workspace root. 

If an `outputPath` is defined in the `project.json` configuration, all buildPaths will be relative to that directory.

Example:

<img width="585" alt="image" src="https://user-images.githubusercontent.com/13395979/235016305-5dd19bc5-a442-4df0-a341-bb3e4987542b.png">


## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #73 

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md) -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
