### PR TITLE
fix(core): use nx dir layout util

### DIFF
--- a/packages/playwright/src/generators/project/__snapshots__/generator.spec.ts.snap
+++ b/packages/playwright/src/generators/project/__snapshots__/generator.spec.ts.snap
@@ -118,6 +118,384 @@ Object {
 }
 `;
 
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "/apps/frontend" should generate "frontend-my-app-e2e" with project's root at "apps/frontend/my-app-e2e": "/apps/frontend" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "frontend-my-app-e2e",
+  "projectType": "application",
+  "root": "apps/frontend/my-app-e2e",
+  "sourceRoot": "apps/frontend/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "apps/frontend/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/apps/frontend/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "/frontend" should generate "frontend-my-app-e2e" with project's root at "apps/frontend/my-app-e2e": "/frontend" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "frontend-my-app-e2e",
+  "projectType": "application",
+  "root": "apps/frontend/my-app-e2e",
+  "sourceRoot": "apps/frontend/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "apps/frontend/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/apps/frontend/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "/packages" should generate "my-app-e2e" with project's root at "packages/my-app-e2e": "/packages" 1`] = `
+Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "my-app-e2e",
+  "projectType": "application",
+  "root": "packages/my-app-e2e",
+  "sourceRoot": "packages/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/packages/my-app-e2e/test-results",
+        "playwrightConfig": "packages/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/packages/my-app-e2e/test-results",
+        "playwrightConfig": "packages/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "packages/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/packages/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "/packages/frontend" should generate "frontend-my-app-e2e" with project's root at "packages/frontend/my-app-e2e": "/packages/frontend" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "frontend-my-app-e2e",
+  "projectType": "application",
+  "root": "packages/frontend/my-app-e2e",
+  "sourceRoot": "packages/frontend/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/packages/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "packages/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/packages/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "packages/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "packages/frontend/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/packages/frontend/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "apps" should generate "my-app-e2e" with project's root at "apps/my-app-e2e": "apps" 1`] = `
+Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "my-app-e2e",
+  "projectType": "application",
+  "root": "apps/my-app-e2e",
+  "sourceRoot": "apps/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/apps/my-app-e2e/test-results",
+        "playwrightConfig": "apps/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/apps/my-app-e2e/test-results",
+        "playwrightConfig": "apps/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "apps/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/apps/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
+exports[`Playwright Project --frontendProject should be able to resolve directory path based on the workspace layout when directory is "apps/frontend" should generate "frontend-my-app-e2e" with project's root at "apps/frontend/my-app-e2e": "apps/frontend" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "frontend-my-app-e2e",
+  "projectType": "application",
+  "root": "apps/frontend/my-app-e2e",
+  "sourceRoot": "apps/frontend/my-app-e2e/src",
+  "tags": Array [],
+  "targets": Object {
+    "debug": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "debug": true,
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "e2e": Object {
+      "configurations": Object {
+        "production": Object {
+          "baseUrl": "https://example.com",
+        },
+      },
+      "executor": "@nxkit/playwright:test",
+      "options": Object {
+        "baseUrl": "https://example.com",
+        "outputPath": "dist/apps/frontend/my-app-e2e/test-results",
+        "playwrightConfig": "apps/frontend/my-app-e2e/playwright.config.ts",
+      },
+      "outputs": Array [
+        "{workspaceRoot}/dist/{projectRoot}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "apps/frontend/my-app-e2e/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+    "show-report": Object {
+      "executor": "@nxkit/playwright:show-report",
+      "options": Object {
+        "reportPath": "dist/apps/frontend/my-app-e2e/playwright-report",
+      },
+    },
+  },
+}
+`;
+
 exports[`Playwright Project should set right path names in \`playwright.config.ts\` 1`] = `
 "import type { PlaywrightTestConfig } from '@playwright/test';
 import { devices } from '@playwright/test';

--- a/packages/playwright/src/generators/project/generator.ts
+++ b/packages/playwright/src/generators/project/generator.ts
@@ -1,5 +1,4 @@
-import { formatFiles, Tree } from '@nx/devkit';
-import { runTasksInSerial } from '@nx/workspace/src/utilities/run-tasks-in-serial';
+import { formatFiles, Tree, runTasksInSerial } from '@nx/devkit';
 import initGenerator from '../init/generator';
 import { addLinter } from './lib/add-linter';
 import { addProjectConfig } from './lib/add-project-config';

--- a/packages/playwright/src/generators/project/lib/normalize-options.ts
+++ b/packages/playwright/src/generators/project/lib/normalize-options.ts
@@ -1,18 +1,29 @@
-import { getWorkspaceLayout, logger, names, Tree } from '@nx/devkit';
+import {
+  extractLayoutDirectory,
+  getWorkspaceLayout,
+  joinPathFragments,
+  logger,
+  names,
+  Tree,
+} from '@nx/devkit';
 import {
   NormalizedProjectGeneratorSchema,
   ProjectGeneratorSchema,
 } from '../schema';
 
-export function normalizeDirectory(options: ProjectGeneratorSchema) {
-  const name = names(options.name).fileName;
-  return options.directory
-    ? `${names(options.directory).fileName}/${name}`
+export function normalizeDirectory(projectName: string, directory: string) {
+  const { projectDirectory } = extractLayoutDirectory(directory);
+  const name = names(projectName).fileName;
+  return projectDirectory
+    ? `${names(projectDirectory).fileName}/${name}`
     : name;
 }
 
-export function normalizeProjectName(options: ProjectGeneratorSchema) {
-  return normalizeDirectory(options).replace(new RegExp('/', 'g'), '-');
+export function normalizeProjectName(projectName: string, directory: string) {
+  return normalizeDirectory(projectName, directory).replace(
+    new RegExp('/', 'g'),
+    '-'
+  );
 }
 
 function getE2EprojectName(options: ProjectGeneratorSchema) {
@@ -45,9 +56,13 @@ export function normalizeOptions(
     options.frontendProject = '';
   }
 
-  const projectDirectory = normalizeDirectory(options);
-  const projectName = normalizeProjectName(options);
-  const projectRoot = `${getWorkspaceLayout(tree).appsDir}/${projectDirectory}`;
+  const projectDirectory = normalizeDirectory(options.name, options.directory);
+  const projectName = normalizeProjectName(options.name, options.directory);
+
+  const { layoutDirectory } = extractLayoutDirectory(options.directory ?? '');
+  const appsDir = layoutDirectory ?? getWorkspaceLayout(tree).appsDir;
+  const projectRoot = joinPathFragments(appsDir, projectDirectory);
+
   const parsedTags = parseTags(options.tags);
 
   return {

--- a/packages/style-dictionary/src/generators/library/__snapshots__/generator.spec.ts.snap
+++ b/packages/style-dictionary/src/generators/library/__snapshots__/generator.spec.ts.snap
@@ -315,6 +315,216 @@ export default config;
 "
 `;
 
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "/libs/shared" should generate "shared-mylib" with project's root at "libs/shared/mylib": "/libs/shared" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "shared-mylib",
+  "projectType": "library",
+  "root": "libs/shared/mylib",
+  "sourceRoot": "libs/shared/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/libs/shared/mylib",
+        "styleDictionaryConfig": "libs/shared/mylib/style-dictionary.config.ts",
+        "tsConfig": "libs/shared/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "libs/shared/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "/packages" should generate "mylib" with project's root at "packages/mylib": "/packages" 1`] = `
+Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "mylib",
+  "projectType": "library",
+  "root": "packages/mylib",
+  "sourceRoot": "packages/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/packages/mylib",
+        "styleDictionaryConfig": "packages/mylib/style-dictionary.config.ts",
+        "tsConfig": "packages/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "packages/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "/packages/shared" should generate "shared-mylib" with project's root at "packages/shared/mylib": "/packages/shared" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "shared-mylib",
+  "projectType": "library",
+  "root": "packages/shared/mylib",
+  "sourceRoot": "packages/shared/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/packages/shared/mylib",
+        "styleDictionaryConfig": "packages/shared/mylib/style-dictionary.config.ts",
+        "tsConfig": "packages/shared/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "packages/shared/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "/shared" should generate "shared-mylib" with project's root at "libs/shared/mylib": "/shared" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "shared-mylib",
+  "projectType": "library",
+  "root": "libs/shared/mylib",
+  "sourceRoot": "libs/shared/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/libs/shared/mylib",
+        "styleDictionaryConfig": "libs/shared/mylib/style-dictionary.config.ts",
+        "tsConfig": "libs/shared/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "libs/shared/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "libs" should generate "mylib" with project's root at "libs/mylib": "libs" 1`] = `
+Object {
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "name": "mylib",
+  "projectType": "library",
+  "root": "libs/mylib",
+  "sourceRoot": "libs/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/libs/mylib",
+        "styleDictionaryConfig": "libs/mylib/style-dictionary.config.ts",
+        "tsConfig": "libs/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "libs/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
+exports[`Style Dictionary Library --preset multiconfig should be able to resolve directory path based on the workspace layout when directory is "libs/shared" should generate "shared-mylib" with project's root at "libs/shared/mylib": "libs/shared" 1`] = `
+Object {
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "name": "shared-mylib",
+  "projectType": "library",
+  "root": "libs/shared/mylib",
+  "sourceRoot": "libs/shared/mylib/src",
+  "tags": Array [],
+  "targets": Object {
+    "build": Object {
+      "executor": "@nxkit/style-dictionary:build",
+      "options": Object {
+        "outputPath": "dist/libs/shared/mylib",
+        "styleDictionaryConfig": "libs/shared/mylib/style-dictionary.config.ts",
+        "tsConfig": "libs/shared/mylib/tsconfig.json",
+      },
+      "outputs": Array [
+        "{options.outputPath}",
+      ],
+    },
+    "lint": Object {
+      "executor": "@nx/linter:eslint",
+      "options": Object {
+        "lintFilePatterns": Array [
+          "libs/shared/mylib/**/*.{js,ts}",
+        ],
+      },
+      "outputs": Array [
+        "{options.outputFile}",
+      ],
+    },
+  },
+}
+`;
+
 exports[`Style Dictionary Library --preset multiconfig should set right path names in \`style-dictionary.config.ts\` 1`] = `
 "import { Config } from 'style-dictionary';
 

--- a/packages/style-dictionary/src/generators/library/lib/normalize-options.ts
+++ b/packages/style-dictionary/src/generators/library/lib/normalize-options.ts
@@ -1,19 +1,41 @@
-import { getWorkspaceLayout, names, Tree } from '@nx/devkit';
+import {
+  extractLayoutDirectory,
+  getWorkspaceLayout,
+  joinPathFragments,
+  names,
+  Tree,
+} from '@nx/devkit';
 import {
   LibraryGeneratorSchema,
   NormalizedLibraryGeneratorSchema,
 } from '../schema';
 
+export function normalizeDirectory(projectName: string, directory: string) {
+  const { projectDirectory } = extractLayoutDirectory(directory);
+  const name = names(projectName).fileName;
+  return projectDirectory
+    ? `${names(projectDirectory).fileName}/${name}`
+    : name;
+}
+
+export function normalizeProjectName(projectName: string, directory: string) {
+  return normalizeDirectory(projectName, directory).replace(
+    new RegExp('/', 'g'),
+    '-'
+  );
+}
+
 export function normalizeOptions(
   tree: Tree,
   options: LibraryGeneratorSchema
 ): NormalizedLibraryGeneratorSchema {
-  const name = names(options.name).fileName;
-  const projectDirectory = options.directory
-    ? `${names(options.directory).fileName}/${name}`
-    : name;
-  const projectName = projectDirectory.replace(new RegExp('/', 'g'), '-');
-  const projectRoot = `${getWorkspaceLayout(tree).libsDir}/${projectDirectory}`;
+  const projectDirectory = normalizeDirectory(options.name, options.directory);
+  const projectName = normalizeProjectName(options.name, options.directory);
+
+  const { layoutDirectory } = extractLayoutDirectory(options.directory ?? '');
+  const libsDir = layoutDirectory ?? getWorkspaceLayout(tree).libsDir;
+  const projectRoot = joinPathFragments(libsDir, projectDirectory);
+
   const parsedTags = options.tags
     ? options.tags.split(',').map((s) => s.trim())
     : [];


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(playwright): button content overflow` -->

## Current Behavior

<!-- This is the behavior we have today -->

When the `directory` option for a project starts with `/` or specifies one of the layout directories (`apps`, `libs`, `packages`) the generated project name contains an unexpected naming. 

Read more about it in qwikifiers/qwik-nx#153

## Expected Behavior

`directory` option starting with `/` or containing one of the layout directories (`apps`, `libs`, `packages`) should end in the right project name.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes qwikifiers/qwik-nx#153

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md) -->

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
