### PR TITLE
Fix 'no properties' error on Windows

### DIFF
--- a/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
+++ b/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
@@ -12,7 +12,9 @@ export function normalizeStyleDictionaryConfig(
   const normalized: Config = {
     ...config,
     source: config.source.map((src) => posix.resolve(projectRoot, src)),
-    include: config?.include?.map((include) => posix.resolve(projectRoot, include)),
+    include: config?.include?.map((include) =>
+      posix.resolve(projectRoot, include)
+    ),
     platforms: Object.entries(config.platforms).reduce(
       (accum: { [key: string]: Platform }, [name, platform]) => ({
         ...accum,

--- a/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
+++ b/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
@@ -1,5 +1,5 @@
 import { ExecutorContext, joinPathFragments } from '@nx/devkit';
-import { resolve } from 'path';
+import { posix } from 'path';
 import type { Config, Platform } from 'style-dictionary';
 import { NormalizedBuildExecutorSchema } from '../schema';
 
@@ -11,8 +11,8 @@ export function normalizeStyleDictionaryConfig(
   const { root: projectRoot } = context.workspace.projects[context.projectName];
   const normalized: Config = {
     ...config,
-    source: config.source.map((src) => resolve(projectRoot, src)),
-    include: config?.include?.map((include) => resolve(projectRoot, include)),
+    source: config.source.map((src) => posix.resolve(projectRoot, src)),
+    include: config?.include?.map((include) => posix.resolve(projectRoot, include)),
     platforms: Object.entries(config.platforms).reduce(
       (accum: { [key: string]: Platform }, [name, platform]) => ({
         ...accum,


### PR DESCRIPTION
By changing the `resolve` function to the POSIX variant, the created path works with the glob function in style-dictionary that uses `{ posix: true }`.

Ref https://github.com/amzn/style-dictionary/blob/17f4cb2f30bd002dfd55d6ef8c5bee4138de8d64/lib/utils/combineJSON.js#L49

Fixes #97 

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md) -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
