### PR TITLE
Change context.workspace to context.projectsConfigurations

### DIFF
--- a/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
+++ b/packages/style-dictionary/src/executors/build/lib/normalize-config.ts
@@ -8,7 +8,8 @@ export function normalizeStyleDictionaryConfig(
   options: NormalizedBuildExecutorSchema,
   context: ExecutorContext
 ): Config {
-  const { root: projectRoot } = context.workspace.projects[context.projectName];
+  const { root: projectRoot } =
+    context.projectsConfigurations.projects[context.projectName];
   const normalized: Config = {
     ...config,
     source: config.source.map((src) => posix.resolve(projectRoot, src)),

--- a/packages/style-dictionary/src/executors/build/lib/normalize-options.ts
+++ b/packages/style-dictionary/src/executors/build/lib/normalize-options.ts
@@ -10,7 +10,8 @@ export function normalizeOptions(
   options: BuildExecutorSchema,
   context: ExecutorContext
 ): NormalizedBuildExecutorSchema {
-  const projectConfig = context.workspace.projects[context.projectName];
+  const projectConfig =
+    context.projectsConfigurations.projects[context.projectName];
   const { sourceRoot, root: projectRoot } = projectConfig;
   const { root } = context;
   return {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(playwright): button content overflow` -->

## Current Behavior

@nxkit/style-dictionary no longer runs with NX v20, throwing this error:

```
TypeError: Cannot read properties of undefined (reading 'projects')
    at normalizeOptions (/opt/atlassian/pipelines/agent/build/node_modules/@nxkit/style-dictionary/src/executors/build/lib/normalize-options.js:7:45)
    at /opt/atlassian/pipelines/agent/build/node_modules/@nxkit/style-dictionary/src/executors/build/executor.js:13:76
    at Generator.next (<anonymous>)
    at /opt/atlassian/pipelines/agent/build/node_modules/tslib/tslib.js:170:75
    at new Promise (<anonymous>)
    at Object.__awaiter (/opt/atlassian/pipelines/agent/build/node_modules/tslib/tslib.js:166:16)
    at buildExecutor (/opt/atlassian/pipelines/agent/build/node_modules/@nxkit/style-dictionary/src/executors/build/executor.js:12:20)
    at runExecutorInternal (/opt/atlassian/pipelines/agent/build/node_modules/nx/src/command-line/run/run.js:98:19)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async /opt/atlassian/pipelines/agent/build/node_modules/nx/src/command-line/run/run.js:176:44
```

<!-- This is the behavior we have today -->

## Expected Behavior

No error is thrown and the plugin works.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->
Caused by https://github.com/nrwl/nx/issues/28461, `workspace` no longer exists in `ExecutorContext`.
The alternative, `projectsConfigurations` has been available since NX v16, so we can use that.

# Checklist:

<!-- - [ ] My code follows the [developer guidelines of this project](https://github.com/nxkit/nxkit/blob/main/CONTRIBUTING.md) -->

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
